### PR TITLE
feat: add route validation middleware

### DIFF
--- a/server/middleware/routeValidator.test.ts
+++ b/server/middleware/routeValidator.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import type { Request, Response, NextFunction } from 'express';
+import { validateRoute } from './routeValidator';
+
+describe('validateRoute', () => {
+  it('calls next when validation succeeds', async () => {
+    const req = { body: { name: 'Jane' }, query: {}, params: {} } as unknown as Request;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response;
+    const next = vi.fn();
+
+    const schema = z.object({
+      body: z.object({ name: z.string() }),
+      query: z.object({}).default({}),
+      params: z.object({}).default({}),
+    });
+
+    await validateRoute(schema)(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('responds with 400 when validation fails', async () => {
+    const req = { body: {}, query: {}, params: {} } as unknown as Request;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response;
+    const next = vi.fn();
+
+    const schema = z.object({
+      body: z.object({ name: z.string() }),
+      query: z.object({}).default({}),
+      params: z.object({}).default({}),
+    });
+
+    await validateRoute(schema)(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'Validation failed',
+      errors: expect.any(Array),
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/server/middleware/routeValidator.ts
+++ b/server/middleware/routeValidator.ts
@@ -1,0 +1,28 @@
+import type { Request, Response, NextFunction } from 'express';
+import { type AnyZodObject, ZodError } from 'zod';
+
+export function validateRoute(schema: AnyZodObject) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const parsed = await schema.parseAsync({
+        body: req.body,
+        query: req.query,
+        params: req.params,
+      });
+
+      req.body = parsed.body;
+      req.query = parsed.query;
+      req.params = parsed.params;
+
+      next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          message: 'Validation failed',
+          errors: error.errors,
+        });
+      }
+      next(error);
+    }
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,10 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./client/src/tests/setup.ts'],
-    include: ['client/src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    include: [
+      'client/src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'server/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+    ],
     exclude: ['node_modules', 'dist', 'build', 'temp', '**/*.e2e.*'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- refine route validation middleware to sanitize request data
- add unit tests covering success and failure cases
- expand Vitest config to include server tests

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install")*
- `npm run test:run` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a20441f448322bdd4af2c1051e06e