### PR TITLE
Align docs with current React/Vite stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ CRM7 is built using a microservices pattern with named services:
 
 ## Technical Stack
 
-- **Frontend**: Next.js 15.1.6, TypeScript, TailwindCSS, shadcn/ui
+- **Frontend**: React 18 with Vite 6, TypeScript, TailwindCSS, shadcn/ui
 - **Backend**: Node.js with Express
 - **Database**: PostgreSQL via Supabase
 - **Authentication**: Supabase Auth with JWT token handling
@@ -139,3 +139,4 @@ CRM7 follows a strategic development roadmap based on comprehensive analysis of 
 ## License
 
 Proprietary - Braden Group Pty Ltd
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ The `images` directory contains screenshots of the application interface for ref
 - Integration with Training.gov.au for qualification and training data
 
 ### User Interface
-- Built with Next.js, TypeScript, TailwindCSS, and shadcn/ui components
+- Built with React, Vite, TypeScript, TailwindCSS, and shadcn/ui components
 - Responsive design for mobile, tablet, and desktop
 - Organized into modules for different functional areas
+

--- a/docs/competitor-comparison.md
+++ b/docs/competitor-comparison.md
@@ -65,7 +65,7 @@ The comparison focuses on key functional areas essential for GTO operations and 
 ### ApprenticeTracker (Current)
 - Modern microservices architecture
 - Integrated approach with public website, admin portals, and CRM
-- Strong technology stack (Next.js, TypeScript, TailwindCSS)
+- Strong technology stack (React, Vite, TypeScript, TailwindCSS)
 
 ## Key Differentiators to Develop
 

--- a/docs/current_implementation_status.md
+++ b/docs/current_implementation_status.md
@@ -19,7 +19,7 @@ The following documentation has been completed and is up-to-date:
 
 - ✅ **Microservices Architecture** - Successfully implemented with named services 
 - ✅ **Database Foundation** - PostgreSQL via Supabase with Drizzle ORM
-- ✅ **Frontend Framework** - Next.js with TypeScript, TailwindCSS, and shadcn/ui 
+- ✅ **Frontend Framework** - React with Vite, TypeScript, TailwindCSS, and shadcn/ui
 - ✅ **Authentication Framework** - JWT token-based authentication with Supabase Auth
 - ✅ **File Storage** - Document management infrastructure for file uploads and retrieval
 - ✅ **API Structure** - RESTful API design patterns implemented

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -121,7 +121,7 @@ The CRM7 platform follows a microservices architecture pattern, with clearly def
 
 ### Frontend
 
-- Next.js 15.1.6
+- React with Vite 6
 - TypeScript
 - TailwindCSS
 - shadcn/ui components

--- a/docs/updated_implementation_roadmap.md
+++ b/docs/updated_implementation_roadmap.md
@@ -4,7 +4,7 @@
 
 ### Completed Milestones
 - **Architectural Foundation** - Established robust microservices architecture with named services for identity, documents, notifications, compliance, training, and placement
-- **Technical Stack Implementation** - Successfully integrated modern tech stack (Next.js, TypeScript, TailwindCSS, shadcn/ui, Supabase/PostgreSQL)
+- **Technical Stack Implementation** - Successfully integrated modern tech stack (React, Vite, TypeScript, TailwindCSS, shadcn/ui, Supabase/PostgreSQL)
 - **Documentation and Planning** - Completed comprehensive gap analysis, national standards alignment documentation, competitor comparison, and initial roadmap
 - **WHS Module (Phase 1)** - Implemented core database structure, API endpoints, and frontend components:
   - Database schema for incidents, risk assessments, inspections, and safety policies

--- a/server/api/settings-routes.ts
+++ b/server/api/settings-routes.ts
@@ -937,7 +937,7 @@ settingsRouter.post('/data-views', async (req: Request, res: Response) => {
       sortBy: viewData.sortBy || 'id',
       sortDirection: viewData.sortDirection || 'asc',
       isPublic: viewData.isPublic !== undefined ? viewData.isPublic : false,
-      userId: 1, // TODO: Get from authenticated user
+      userId: req.user?.id || 1,
       createdAt: new Date(),
       updatedAt: new Date(),
     });


### PR DESCRIPTION
## Summary
- Document current frontend stack as React + Vite across project documentation
- Use authenticated user ID when creating settings data views

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689a27e293dc83228280534338d37df4

## Summary by Sourcery

Align project documentation to reflect the current React+Vite frontend stack and update settings-routes to use the authenticated user’s ID when creating data views.

Enhancements:
- Standardize references to React with Vite instead of Next.js across all documentation files
- Adapt settings-routes to use req.user.id (with fallback) for userId instead of hardcoding

Documentation:
- Update README.md, docs/README.md, competitor-comparison.md, current_implementation_status.md, system-architecture.md, and updated_implementation_roadmap.md to list React+Vite as the frontend framework